### PR TITLE
Fix vscode intellisense.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,8 +37,10 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
+    "paths": {
+      "shared/*": ["./shared/*"]
+    } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
Intellisense would always assume there was a missing module when importing `shared` because of how the webpack aliases are set up.

Added `./shared` to the paths in tsconfig.json for Intellisense to recognize the shared module's existence