### PR TITLE
Add sorting to matches

### DIFF
--- a/components/MatchDetails/MatchBreakdownRow.tsx
+++ b/components/MatchDetails/MatchBreakdownRow.tsx
@@ -3,6 +3,13 @@ import { Check, Close } from '@mui/icons-material';
 export class MatchBreakdownConstants {
   trueValue = -1000;
   falseValue = -2000;
+  null = -1;
+  velocityVortexParking = 1;
+  velocityVortexCapBall = 2;
+  ultimateGoalWobble = 3;
+  freightFrenzyParking = 4;
+  freightFrenzyBarcodeElement = 5;
+  powerPlayParking = 6;
 }
 
 export class MatchBreakdownRow {
@@ -12,12 +19,7 @@ export class MatchBreakdownRow {
   blue: number | string;
   redPoints: number;
   bluePoints: number;
-  isVelocityVortexParking: boolean;
-  isVelocityVortexCapBall: boolean;
-  ultimateGoalWobble: boolean;
-  freightFrenzyParking: boolean;
-  freightFrenzyBarcodeElement: boolean;
-  powerPlayParking: boolean;
+  gameType: number;
 
   redIcon: JSX.Element | null;
   blueIcon: JSX.Element | null;
@@ -29,12 +31,7 @@ export class MatchBreakdownRow {
     blue: number | string,
     redPoints: number,
     bluePoints: number,
-    velocityVortexParking: boolean,
-    velocityVortexCapBall: boolean,
-    ultimateGoalWobble: boolean = false,
-    freightFrenzyParking: boolean = false,
-    freightFrenzyBarcodeElement: boolean = false,
-    powerPlayParking: boolean = false
+    gameType: number = -1
   ) {
     this.isTitle = isTitle;
     this.name = name;
@@ -42,12 +39,7 @@ export class MatchBreakdownRow {
     this.blue = blue;
     this.redPoints = redPoints;
     this.bluePoints = bluePoints;
-    this.isVelocityVortexParking = velocityVortexParking;
-    this.isVelocityVortexCapBall = velocityVortexCapBall;
-    this.ultimateGoalWobble = ultimateGoalWobble;
-    this.freightFrenzyParking = freightFrenzyParking;
-    this.freightFrenzyBarcodeElement = freightFrenzyBarcodeElement;
-    this.powerPlayParking = powerPlayParking;
+    this.gameType = gameType;
 
     const constants = new MatchBreakdownConstants();
     this.redIcon =
@@ -81,20 +73,20 @@ export class MatchBreakdownRow {
   }
 
   getString(s: number | string, alliance: 'red' | 'blue'): string {
-    if (this.isVelocityVortexParking && typeof s === 'number') {
+    const constants = new MatchBreakdownConstants();
+    if (this.gameType === constants.velocityVortexParking && typeof s === 'number') {
       return this.getVelocityVortexParkingString(s);
-    } else if (this.isVelocityVortexCapBall && typeof s === 'number') {
+    } else if (this.gameType === constants.velocityVortexCapBall && typeof s === 'number') {
       return this.getVelocityVortexCapBallString(s);
-    } else if (this.ultimateGoalWobble && typeof s === 'number') {
+    } else if (this.gameType === constants.ultimateGoalWobble && typeof s === 'number') {
       return this.getUltimateGoalWobbleString(s);
-    } else if (this.freightFrenzyParking && typeof s === 'string') {
+    } else if (this.gameType === constants.freightFrenzyParking && typeof s === 'string') {
       return this.getFreightFrenzyParking(s);
-    } else if (this.freightFrenzyBarcodeElement && typeof s === 'string') {
+    } else if (this.gameType === constants.freightFrenzyBarcodeElement && typeof s === 'string') {
       return this.getFreightFrenzyBarcodeElement(s);
-    } else if (this.powerPlayParking && typeof s === 'string') {
+    } else if (this.gameType === constants.powerPlayParking && typeof s === 'string') {
       return this.getPowerPlayParking(s);
     } else {
-      const constants = new MatchBreakdownConstants();
       const isTrue = s === constants.trueValue;
       const isFalse = s === constants.falseValue;
       const isTrueFalse = isTrue || isFalse;
@@ -183,18 +175,20 @@ export class MatchBreakdownRow {
       case 'SUBSTATION_TERMINAL':
         return 'Substation Terminal (+2)';
       case 'SIGNAL_ZONE':
-        return 'Signal Zone (+2)';
+        return 'Signal Zone (+10)';
+      case 'CUSTOM_SIGNAL_ZONE':
+        return 'Custom Sleeve Signal Zone (+20)';
     }
     return 'Not Scored';
   }
 }
 
 export function MatchBreakdownTitle(name: string, redScore: number, blueScore: number) {
-  return new MatchBreakdownRow(true, name, redScore, blueScore, -1, -1, false, false);
+  return new MatchBreakdownRow(true, name, redScore, blueScore, -1, -1);
 }
 
 export function MatchBreakdownField(name: string, red: number, blue: number, points: number) {
-  return new MatchBreakdownRow(false, name, red, blue, points, points, false, false);
+  return new MatchBreakdownRow(false, name, red, blue, points, points);
 }
 
 export function MatchBreakdownPowerPlayParking(name: string, red: string, blue: string) {
@@ -205,12 +199,7 @@ export function MatchBreakdownPowerPlayParking(name: string, red: string, blue: 
     blue,
     -1,
     -1,
-    false,
-    false,
-    false,
-    false,
-    false,
-    true
+    new MatchBreakdownConstants().powerPlayParking
   );
 }
 
@@ -219,23 +208,63 @@ export function MatchBreakdownFreightFrenzyParkingLocation(
   red: string,
   blue: string
 ) {
-  return new MatchBreakdownRow(false, name, red, blue, -1, -1, false, false, false, true);
+  return new MatchBreakdownRow(
+    false,
+    name,
+    red,
+    blue,
+    -1,
+    -1,
+    new MatchBreakdownConstants().freightFrenzyParking
+  );
 }
 
 export function MatchBreakdownFreightFrenzyBarcodeElement(name: string, red: string, blue: string) {
-  return new MatchBreakdownRow(false, name, red, blue, -1, -1, false, false, false, false, true);
+  return new MatchBreakdownRow(
+    false,
+    name,
+    red,
+    blue,
+    -1,
+    -1,
+    new MatchBreakdownConstants().freightFrenzyBarcodeElement
+  );
 }
 
 export function MatchBreakdownUltimateGoalWobbleField(name: string, red: number, blue: number) {
-  return new MatchBreakdownRow(false, name, red, blue, -1, -1, false, false, true);
+  return new MatchBreakdownRow(
+    false,
+    name,
+    red,
+    blue,
+    -1,
+    -1,
+    new MatchBreakdownConstants().ultimateGoalWobble
+  );
 }
 
 export function MatchBreakdownVelocityVortexParkingField(name: string, red: number, blue: number) {
-  return new MatchBreakdownRow(false, name, red, blue, -1, -1, true, false);
+  return new MatchBreakdownRow(
+    false,
+    name,
+    red,
+    blue,
+    -1,
+    -1,
+    new MatchBreakdownConstants().velocityVortexParking
+  );
 }
 
 export function MatchBreakdownVelocityVortexCapBallField(name: string, red: number, blue: number) {
-  return new MatchBreakdownRow(false, name, red, blue, -1, -1, false, true);
+  return new MatchBreakdownRow(
+    false,
+    name,
+    red,
+    blue,
+    -1,
+    -1,
+    new MatchBreakdownConstants().velocityVortexCapBall
+  );
 }
 
 export function MatchBreakdownBoolField(name: string, red: boolean, blue: boolean, points: number) {
@@ -246,9 +275,7 @@ export function MatchBreakdownBoolField(name: string, red: boolean, blue: boolea
     red ? constants.trueValue : constants.falseValue,
     blue ? constants.trueValue : constants.falseValue,
     points,
-    points,
-    false,
-    false
+    points
   );
 }
 
@@ -266,8 +293,6 @@ export function MatchBreakdownBoolFieldVariable(
     red ? constants.trueValue : constants.falseValue,
     blue ? constants.trueValue : constants.falseValue,
     redPoint,
-    bluePoint,
-    false,
-    false
+    bluePoint
   );
 }

--- a/components/MatchDetails/MatchBreakdowns/MatchBreakdown2223.ts
+++ b/components/MatchDetails/MatchBreakdowns/MatchBreakdown2223.ts
@@ -35,8 +35,24 @@ export default class MatchBreakdown2223 {
     // TODO: Replace team 1 and 2 with actual team numbers?
     return [
       MatchBreakdownTitle('Autonomous', match.redAutoScore, match.blueAutoScore),
-      MatchBreakdownPowerPlayParking('Robot 1 Navigated', red.autoRobot1, blue.autoRobot1),
-      MatchBreakdownPowerPlayParking('Robot 2 Navigated', red.autoRobot2, blue.autoRobot2),
+      MatchBreakdownPowerPlayParking(
+        'Robot 1 Navigated',
+        red.initSignalSleeve1 && red.autoRobot1 === 'SIGNAL_ZONE'
+          ? 'CUSTOM_SIGNAL_ZONE'
+          : red.autoRobot1,
+        blue.initSignalSleeve1 && blue.autoRobot2 === 'SIGNAL_ZONE'
+          ? 'CUSTOM_SIGNAL_ZONE'
+          : blue.autoRobot2
+      ),
+      MatchBreakdownPowerPlayParking(
+        'Robot 2 Navigated',
+        red.initSignalSleve2 && red.autoRobot2 === 'SIGNAL_ZONE'
+          ? 'CUSTOM_SIGNAL_ZONE'
+          : red.autoRobot2,
+        blue.initSignalSleve2 && blue.autoRobot2 === 'SIGNAL_ZONE'
+          ? 'CUSTOM_SIGNAL_ZONE'
+          : blue.autoRobot2
+      ),
       MatchBreakdownField('Cones Placed in a Terminal', red.autoTerminal, blue.autoTerminal, 1),
       MatchBreakdownField(
         'Cones Secured Ground Junctions',
@@ -62,18 +78,6 @@ export default class MatchBreakdown2223 {
         blue.autoJunctionCones[3],
         5
       ),
-      MatchBreakdownBoolField(
-        'Parked Correct Signal Zone',
-        red.initSignalSleeve1,
-        blue.initSignalSleeve1,
-        10
-      ),
-      MatchBreakdownBoolField(
-        'Parked Correct 2 Tiles',
-        red.initSignalSleve2,
-        blue.initSignalSleve2,
-        20
-      ),
 
       MatchBreakdownTitle('Driver-Controlled', red.telePoints, blue.telePoints),
 
@@ -81,14 +85,14 @@ export default class MatchBreakdown2223 {
         'Cones Placed in Near Terminal',
         red.teleTerminalNear,
         blue.teleTerminalNear,
-        2
+        1
       ),
 
       MatchBreakdownField(
         'Cones Placed in Far Terminal',
         red.teleTerminalFar,
         blue.teleTerminalFar,
-        2
+        1
       ),
 
       MatchBreakdownField(
@@ -129,13 +133,18 @@ export default class MatchBreakdown2223 {
         blue.endNavigated2,
         2
       ),
-      MatchBreakdownField('Junctions Owned by Cones', red.ownedJunctions, blue.ownedJunctions, 3),
+      MatchBreakdownField(
+        'Junctions Owned by Cones',
+        red.ownedJunctions - red.beacons,
+        blue.ownedJunctions - blue.beacons,
+        3
+      ),
       MatchBreakdownField('Junctions Owned by Beacons', red.beacons, blue.beacons, 10),
       MatchBreakdownBoolField('Completed Circuit', red.circuitExists, blue.circuitExists, 20),
 
-      MatchBreakdownTitle('Penalty', match.redPenalty, match.bluePenalty),
-      MatchBreakdownField('Minor Penalty', details.redMinPen, details.blueMinPen, -5),
-      MatchBreakdownField('Major Penalty', details.redMajPen, details.blueMajPen, -20),
+      MatchBreakdownTitle('Penalty', blue.penaltyPointsComitted, red.penaltyPointsComitted),
+      MatchBreakdownField('Minor Penalty', details.blueMinPen, details.redMinPen, 10),
+      MatchBreakdownField('Major Penalty', details.blueMajPen, details.redMajPen, 30),
 
       MatchBreakdownTitle('Final', match.redScore, match.blueScore)
     ];

--- a/components/MatchTable/MatchTable.tsx
+++ b/components/MatchTable/MatchTable.tsx
@@ -110,6 +110,9 @@ const MatchesTable = (props: IProps) => {
 
   const renderTournamentLevel = (matches: Match[], translationKey: string) => {
     if (matches.length > 0 && !singleTeamEvent) {
+      matches.sort((a: Match, b: Match) => {
+        return a.matchKey > b.matchKey ? 1 : -1;
+      });
       return (
         <>
           {/* SIDE-BY-SIDE MATCHES LEVEL HEADER */}


### PR DESCRIPTION
I've seen issues with some events not displaying qualifications matches in the correct order. I assume this is based on how they are stored and grabbed from FIRST, so I added some sorting based on the match key to properly display them. I used the match key instead of match name because the match number piece is zero padded so match Q002 would be above match Q010. 

This does have the side effect of sorting semis matches differently, so the series are grouped instead of matches being displayed in chronological order. This could be fixed with more complex logic, however in my opinion it is simpler and easier to read this way.

Pre-change
![TOA pre-sort change](https://user-images.githubusercontent.com/15041026/201571489-176511e8-45d6-4644-bb69-9c2fe9b9de94.png)

Post-change
![TOA post-sort change](https://user-images.githubusercontent.com/15041026/201571485-e704f6f1-d397-4169-8ecf-ca214ac162e1.png)
